### PR TITLE
Update URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,253 +14,253 @@
 
 <ul>
 <h2>Language</h2>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_01">intro</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02">quoting</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05">variables</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06">expansion</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07">redirection</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08">exit status</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09">commands</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_10">grammar</a></li>
-<li><a href="http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_11">signals</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_01">intro</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02">quoting</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05">variables</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06">expansion</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07">redirection</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08">exit status</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09">commands</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_10">grammar</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_11">signals</a></li>
 
 <h2 style='margin:40px 0 0 0'>Built-in</h2>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_18">.</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_16">:</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_15">break</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_17">continue</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_19">eval</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_20">exec</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_21">exit</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_22">export</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_23">readonly</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_24">return</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_25">set</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_26">shift</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_27">times</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_28">trap</a></li>
-<li><a href="http://www.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_29">unset</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_18">.</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_16">:</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_15">break</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_17">continue</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_19">eval</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_20">exec</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_21">exit</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_22">export</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_23">readonly</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_24">return</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_25">set</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_26">shift</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_27">times</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_28">trap</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_29">unset</a></li>
 </ul>
 
 <ul>
 <h2>Programming</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/alias.html#top'>alias</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/bc.html#top'>bc</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/command.html#top'>command</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/date.html#top'>date</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/env.html#top'>env</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/expr.html#top'>expr</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/false.html#top'>false</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/getopts.html#top'>getopts</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/hash.html#top'>hash</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/fc.html#top'>fc</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/id.html#top'>id</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/locale.html#top'>locale</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/localedef.html#top'>localedef</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/logger.html#top'>logger</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/logname.html#top'>logname</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/newgrp.html#top'>newgrp</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/pathchk.html#top'>pathchk</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/pwd.html#top'>pwd</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/read.html#top'>read</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/sh.html#top'>sh</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/sleep.html#top'>sleep</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/test.html#top'>test</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/time.html#top'>time</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/tput.html#top'>tput</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/true.html#top'>true</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/type.html#top'>type</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/unalias.html#top'>unalias</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uname.html#top'>uname</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/write.html#top'>write</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/xargs.html#top'>xargs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/alias.html#top'>alias</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/bc.html#top'>bc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html#top'>command</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/date.html#top'>date</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/env.html#top'>env</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/expr.html#top'>expr</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/false.html#top'>false</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/getopts.html#top'>getopts</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/hash.html#top'>hash</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fc.html#top'>fc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/id.html#top'>id</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/locale.html#top'>locale</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/localedef.html#top'>localedef</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/logger.html#top'>logger</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/logname.html#top'>logname</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/newgrp.html#top'>newgrp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pathchk.html#top'>pathchk</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pwd.html#top'>pwd</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/read.html#top'>read</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html#top'>sh</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sleep.html#top'>sleep</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html#top'>test</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/time.html#top'>time</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tput.html#top'>tput</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/true.html#top'>true</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/type.html#top'>type</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unalias.html#top'>unalias</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uname.html#top'>uname</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/write.html#top'>write</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/xargs.html#top'>xargs</a></li>
 </ul>
 
 
 <ul>
 <h2>Text</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/awk.html#top'>awk</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cat.html#top'>cat</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cksum.html#top'>cksum</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cmp.html#top'>cmp</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/comm.html#top'>comm</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/csplit.html#top'>csplit</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cut.html#top'>cut</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/echo.html#top'>echo</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ed.html#top'>ed</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ex.html#top'>ex</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/expand.html#top'>expand</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/fold.html#top'>fold</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/grep.html#top'>grep</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/head.html#top'>head</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/join.html#top'>join</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/more.html#top'>more</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/nl.html#top'>nl</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/od.html#top'>od</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/paste.html#top'>paste</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/printf.html#top'>printf</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/sed.html#top'>sed</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/sort.html#top'>sort</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/split.html#top'>split</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/tail.html#top'>tail</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/tr.html#top'>tr</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/tsort.html#top'>tsort</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/unexpand.html#top'>unexpand</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uniq.html#top'>uniq</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/wc.html#top'>wc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html#top'>awk</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cat.html#top'>cat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cksum.html#top'>cksum</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cmp.html#top'>cmp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/comm.html#top'>comm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/csplit.html#top'>csplit</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cut.html#top'>cut</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#top'>echo</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ed.html#top'>ed</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html#top'>ex</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/expand.html#top'>expand</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fold.html#top'>fold</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html#top'>grep</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/head.html#top'>head</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/join.html#top'>join</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/more.html#top'>more</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nl.html#top'>nl</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/od.html#top'>od</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/paste.html#top'>paste</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html#top'>printf</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sed.html#top'>sed</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sort.html#top'>sort</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/split.html#top'>split</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tail.html#top'>tail</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tr.html#top'>tr</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tsort.html#top'>tsort</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unexpand.html#top'>unexpand</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uniq.html#top'>uniq</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/wc.html#top'>wc</a></li>
 </ul>
 
 <ul>
 <h2>Files</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/basename.html#top'>basename</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cal.html#top'>cal</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cd.html#top'>cd</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/chgrp.html#top'>chgrp</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/chmod.html#top'>chmod</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/chown.html#top'>chown</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cp.html#top'>cp</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/dd.html#top'>dd</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/df.html#top'>df</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/dirname.html#top'>dirname</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/du.html#top'>du</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/file.html#top'>file</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/find.html#top'>find</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/fuser.html#top'>fuser</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/link.html#top'>link</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ln.html#top'>ln</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ls.html#top'>ls</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html#top'>mkdir</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/mkfifo.html#top'>mkfifo</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/mv.html#top'>mv</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/rm.html#top'>rm</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/rmdir.html#top'>rmdir</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/tee.html#top'>tee</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/touch.html#top'>touch</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/unlink.html#top'>unlink</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/basename.html#top'>basename</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cal.html#top'>cal</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cd.html#top'>cd</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/chgrp.html#top'>chgrp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/chmod.html#top'>chmod</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/chown.html#top'>chown</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cp.html#top'>cp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/dd.html#top'>dd</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/df.html#top'>df</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/dirname.html#top'>dirname</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/du.html#top'>du</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/file.html#top'>file</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/find.html#top'>find</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fuser.html#top'>fuser</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/link.html#top'>link</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ln.html#top'>ln</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ls.html#top'>ls</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html#top'>mkdir</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkfifo.html#top'>mkfifo</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mv.html#top'>mv</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/rm.html#top'>rm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/rmdir.html#top'>rmdir</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tee.html#top'>tee</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/touch.html#top'>touch</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unlink.html#top'>unlink</a></li>
 </ul>
 
 <ul>
 <h2>Processes</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/bg.html#top'>bg</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/fg.html#top'>fg</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/kill.html#top'>kill</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/nice.html#top'>nice</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/nohup.html#top'>nohup</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ps.html#top'>ps</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/renice.html#top'>renice</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/wait.html#top'>wait</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/bg.html#top'>bg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fg.html#top'>fg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/kill.html#top'>kill</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nice.html#top'>nice</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nohup.html#top'>nohup</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html#top'>ps</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/renice.html#top'>renice</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/wait.html#top'>wait</a></li>
 </ul>
 
 <ul>
 <h2>Job Control</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/at.html#top'>at</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/batch.html#top'>batch</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/jobs.html#top'>jobs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/at.html#top'>at</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/batch.html#top'>batch</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/jobs.html#top'>jobs</a></li>
 </ul>
 
 <hr style='clear:both;margin:20px 0'>
 
 <ul>
 <h2>Development</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ar.html#top'>ar</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/asa.html#top'>asa</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/c99.html#top'>c99</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cflow.html#top'>cflow</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ctags.html#top'>ctags</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/cxref.html#top'>cxref</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/diff.html#top'>diff</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/fort77.html#top'>fort77</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/gencat.html#top'>gencat</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/iconv.html#top'>iconv</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/lex.html#top'>lex</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/m4.html#top'>m4</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/make.html#top'>make</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/man.html#top'>man</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/nm.html#top'>nm</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/patch.html#top'>patch</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/strings.html#top'>strings</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/strip.html#top'>strip</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/vi.html#top'>vi</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/yacc.html#top'>yacc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ar.html#top'>ar</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/asa.html#top'>asa</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/c99.html#top'>c99</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cflow.html#top'>cflow</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ctags.html#top'>ctags</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cxref.html#top'>cxref</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/diff.html#top'>diff</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fort77.html#top'>fort77</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/gencat.html#top'>gencat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/iconv.html#top'>iconv</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/lex.html#top'>lex</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/m4.html#top'>m4</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html#top'>make</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/man.html#top'>man</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nm.html#top'>nm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/patch.html#top'>patch</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/strings.html#top'>strings</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/strip.html#top'>strip</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/vi.html#top'>vi</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/yacc.html#top'>yacc</a></li>
 </ul>
 
 <ul>
 <h2>Admin</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#top'>crontab</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/getconf.html#top'>getconf</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ulimit.html#top'>ulimit</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/umask.html#top'>umask</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/who.html#top'>who</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#top'>crontab</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html#top'>getconf</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ulimit.html#top'>ulimit</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/umask.html#top'>umask</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/who.html#top'>who</a></li>
 </ul>
 
 <ul>
 <h2>Terminal</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/stty.html#top'>stty</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/tabs.html#top'>tabs</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/tty.html#top'>tty</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/stty.html#top'>stty</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tabs.html#top'>tabs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tty.html#top'>tty</a></li>
 </ul>
 
 <ul>
 <h2>Comm</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/mailx.html#top'>mailx</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/mesg.html#top'>mesg</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/talk.html#top'>talk</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uucp.html#top'>uucp</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uudecode.html#top'>uudecode</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uuencode.html#top'>uuencode</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uustat.html#top'>uustat</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uux.html#top'>uux</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mailx.html#top'>mailx</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mesg.html#top'>mesg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/talk.html#top'>talk</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uucp.html#top'>uucp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uudecode.html#top'>uudecode</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uuencode.html#top'>uuencode</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uustat.html#top'>uustat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uux.html#top'>uux</a></li>
 </ul>
 
 <ul>
 <h2>Compression</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/compress.html#top'>compress</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/pax.html#top'>pax</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/uncompress.html#top'>uncompress</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/zcat.html#top'>zcat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/compress.html#top'>compress</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html#top'>pax</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uncompress.html#top'>uncompress</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/zcat.html#top'>zcat</a></li>
 </ul>
 
 <div class='misc'>
 
 <ul>
 <h2>Message Queues</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ipcrm.html#top'>ipcrm</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/ipcs.html#top'>ipcs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ipcrm.html#top'>ipcrm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ipcs.html#top'>ipcs</a></li>
 </ul>
 
 <ul>
 <h2>Print</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/lp.html#top'>lp</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/pr.html#top'>pr</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/lp.html#top'>lp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pr.html#top'>pr</a></li>
 </ul>
 
 <ul>
 <h2>Batch Jobs</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qalter.html#top'>qalter</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qdel.html#top'>qdel</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qhold.html#top'>qhold</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qmove.html#top'>qmove</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qmsg.html#top'>qmsg</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qrerun.html#top'>qrerun</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qrls.html#top'>qrls</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qselect.html#top'>qselect</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qsig.html#top'>qsig</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qstat.html#top'>qstat</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/qsub.html#top'>qsub</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qalter.html#top'>qalter</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qdel.html#top'>qdel</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qhold.html#top'>qhold</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qmove.html#top'>qmove</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qmsg.html#top'>qmsg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qrerun.html#top'>qrerun</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qrls.html#top'>qrls</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qselect.html#top'>qselect</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qsig.html#top'>qsig</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qstat.html#top'>qstat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qsub.html#top'>qsub</a></li>
 </ul>
 
 <ul>
 <h2>SCCS</h2>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/admin.html#top'>admin</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/delta.html#top'>delta</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/get.html#top'>get</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/prs.html#top'>prs</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/rmdel.html#top'>rmdel</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/sact.html#top'>sact</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/sccs.html#top'>sccs</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/unget.html#top'>unget</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/val.html#top'>val</a></li>
-<li><a href='http://www.opengroup.org/onlinepubs/9699919799/utilities/what.html#top'>what</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/admin.html#top'>admin</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/delta.html#top'>delta</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/get.html#top'>get</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/prs.html#top'>prs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/rmdel.html#top'>rmdel</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sact.html#top'>sact</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sccs.html#top'>sccs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unget.html#top'>unget</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/val.html#top'>val</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/what.html#top'>what</a></li>
 </ul>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -14,253 +14,253 @@
 
 <ul>
 <h2>Language</h2>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_01">intro</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02">quoting</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05">variables</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06">expansion</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07">redirection</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08">exit status</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09">commands</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_10">grammar</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_11">signals</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_01">intro</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_02">quoting</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_05">variables</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_06">expansion</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_07">redirection</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_08">exit status</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_09">commands</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_10">grammar</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_11">signals</a></li>
 
 <h2 style='margin:40px 0 0 0'>Built-in</h2>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_18">.</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_16">:</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_15">break</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_17">continue</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_19">eval</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_20">exec</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_21">exit</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_22">export</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_23">readonly</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_24">return</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_25">set</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_26">shift</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_27">times</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_28">trap</a></li>
-<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_29">unset</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_18">.</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_16">:</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_15">break</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_17">continue</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_19">eval</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_20">exec</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_21">exit</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_22">export</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_23">readonly</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_24">return</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_25">set</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_26">shift</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_27">times</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_28">trap</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_29">unset</a></li>
 </ul>
 
 <ul>
 <h2>Programming</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/alias.html#top'>alias</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/bc.html#top'>bc</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html#top'>command</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/date.html#top'>date</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/env.html#top'>env</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/expr.html#top'>expr</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/false.html#top'>false</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/getopts.html#top'>getopts</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/hash.html#top'>hash</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fc.html#top'>fc</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/id.html#top'>id</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/locale.html#top'>locale</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/localedef.html#top'>localedef</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/logger.html#top'>logger</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/logname.html#top'>logname</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/newgrp.html#top'>newgrp</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pathchk.html#top'>pathchk</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pwd.html#top'>pwd</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/read.html#top'>read</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html#top'>sh</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sleep.html#top'>sleep</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html#top'>test</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/time.html#top'>time</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tput.html#top'>tput</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/true.html#top'>true</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/type.html#top'>type</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unalias.html#top'>unalias</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uname.html#top'>uname</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/write.html#top'>write</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/xargs.html#top'>xargs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/alias.html#top'>alias</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/bc.html#top'>bc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/command.html#top'>command</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/date.html#top'>date</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/env.html#top'>env</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/expr.html#top'>expr</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/false.html#top'>false</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/getopts.html#top'>getopts</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/hash.html#top'>hash</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/fc.html#top'>fc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/id.html#top'>id</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/locale.html#top'>locale</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/localedef.html#top'>localedef</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/logger.html#top'>logger</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/logname.html#top'>logname</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/newgrp.html#top'>newgrp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/pathchk.html#top'>pathchk</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/pwd.html#top'>pwd</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/read.html#top'>read</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sh.html#top'>sh</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sleep.html#top'>sleep</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/test.html#top'>test</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/time.html#top'>time</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/tput.html#top'>tput</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/true.html#top'>true</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/type.html#top'>type</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/unalias.html#top'>unalias</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uname.html#top'>uname</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/write.html#top'>write</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/xargs.html#top'>xargs</a></li>
 </ul>
 
 
 <ul>
 <h2>Text</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html#top'>awk</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cat.html#top'>cat</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cksum.html#top'>cksum</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cmp.html#top'>cmp</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/comm.html#top'>comm</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/csplit.html#top'>csplit</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cut.html#top'>cut</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#top'>echo</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ed.html#top'>ed</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html#top'>ex</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/expand.html#top'>expand</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fold.html#top'>fold</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html#top'>grep</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/head.html#top'>head</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/join.html#top'>join</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/more.html#top'>more</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nl.html#top'>nl</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/od.html#top'>od</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/paste.html#top'>paste</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html#top'>printf</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sed.html#top'>sed</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sort.html#top'>sort</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/split.html#top'>split</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tail.html#top'>tail</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tr.html#top'>tr</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tsort.html#top'>tsort</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unexpand.html#top'>unexpand</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uniq.html#top'>uniq</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/wc.html#top'>wc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/awk.html#top'>awk</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cat.html#top'>cat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cksum.html#top'>cksum</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cmp.html#top'>cmp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/comm.html#top'>comm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/csplit.html#top'>csplit</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cut.html#top'>cut</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/echo.html#top'>echo</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ed.html#top'>ed</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ex.html#top'>ex</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/expand.html#top'>expand</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/fold.html#top'>fold</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/grep.html#top'>grep</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/head.html#top'>head</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/join.html#top'>join</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/more.html#top'>more</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/nl.html#top'>nl</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/od.html#top'>od</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/paste.html#top'>paste</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/printf.html#top'>printf</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sed.html#top'>sed</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sort.html#top'>sort</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/split.html#top'>split</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/tail.html#top'>tail</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/tr.html#top'>tr</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/tsort.html#top'>tsort</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/unexpand.html#top'>unexpand</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uniq.html#top'>uniq</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/wc.html#top'>wc</a></li>
 </ul>
 
 <ul>
 <h2>Files</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/basename.html#top'>basename</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cal.html#top'>cal</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cd.html#top'>cd</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/chgrp.html#top'>chgrp</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/chmod.html#top'>chmod</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/chown.html#top'>chown</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cp.html#top'>cp</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/dd.html#top'>dd</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/df.html#top'>df</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/dirname.html#top'>dirname</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/du.html#top'>du</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/file.html#top'>file</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/find.html#top'>find</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fuser.html#top'>fuser</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/link.html#top'>link</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ln.html#top'>ln</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ls.html#top'>ls</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html#top'>mkdir</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkfifo.html#top'>mkfifo</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mv.html#top'>mv</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/rm.html#top'>rm</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/rmdir.html#top'>rmdir</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tee.html#top'>tee</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/touch.html#top'>touch</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unlink.html#top'>unlink</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/basename.html#top'>basename</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cal.html#top'>cal</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cd.html#top'>cd</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/chgrp.html#top'>chgrp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/chmod.html#top'>chmod</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/chown.html#top'>chown</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cp.html#top'>cp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/dd.html#top'>dd</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/df.html#top'>df</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/dirname.html#top'>dirname</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/du.html#top'>du</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/file.html#top'>file</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/find.html#top'>find</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/fuser.html#top'>fuser</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/link.html#top'>link</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ln.html#top'>ln</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ls.html#top'>ls</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/mkdir.html#top'>mkdir</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/mkfifo.html#top'>mkfifo</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/mv.html#top'>mv</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/rm.html#top'>rm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/rmdir.html#top'>rmdir</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/tee.html#top'>tee</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/touch.html#top'>touch</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/unlink.html#top'>unlink</a></li>
 </ul>
 
 <ul>
 <h2>Processes</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/bg.html#top'>bg</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fg.html#top'>fg</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/kill.html#top'>kill</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nice.html#top'>nice</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nohup.html#top'>nohup</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html#top'>ps</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/renice.html#top'>renice</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/wait.html#top'>wait</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/bg.html#top'>bg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/fg.html#top'>fg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/kill.html#top'>kill</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/nice.html#top'>nice</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/nohup.html#top'>nohup</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ps.html#top'>ps</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/renice.html#top'>renice</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/wait.html#top'>wait</a></li>
 </ul>
 
 <ul>
 <h2>Job Control</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/at.html#top'>at</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/batch.html#top'>batch</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/jobs.html#top'>jobs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/at.html#top'>at</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/batch.html#top'>batch</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/jobs.html#top'>jobs</a></li>
 </ul>
 
 <hr style='clear:both;margin:20px 0'>
 
 <ul>
 <h2>Development</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ar.html#top'>ar</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/asa.html#top'>asa</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/c99.html#top'>c99</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cflow.html#top'>cflow</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ctags.html#top'>ctags</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cxref.html#top'>cxref</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/diff.html#top'>diff</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fort77.html#top'>fort77</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/gencat.html#top'>gencat</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/iconv.html#top'>iconv</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/lex.html#top'>lex</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/m4.html#top'>m4</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html#top'>make</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/man.html#top'>man</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nm.html#top'>nm</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/patch.html#top'>patch</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/strings.html#top'>strings</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/strip.html#top'>strip</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/vi.html#top'>vi</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/yacc.html#top'>yacc</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ar.html#top'>ar</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/asa.html#top'>asa</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/c99.html#top'>c99</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cflow.html#top'>cflow</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ctags.html#top'>ctags</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/cxref.html#top'>cxref</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/diff.html#top'>diff</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/fort77.html#top'>fort77</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/gencat.html#top'>gencat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/iconv.html#top'>iconv</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/lex.html#top'>lex</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/m4.html#top'>m4</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/make.html#top'>make</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/man.html#top'>man</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/nm.html#top'>nm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/patch.html#top'>patch</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/strings.html#top'>strings</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/strip.html#top'>strip</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/vi.html#top'>vi</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/yacc.html#top'>yacc</a></li>
 </ul>
 
 <ul>
 <h2>Admin</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#top'>crontab</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html#top'>getconf</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ulimit.html#top'>ulimit</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/umask.html#top'>umask</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/who.html#top'>who</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/crontab.html#top'>crontab</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/getconf.html#top'>getconf</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ulimit.html#top'>ulimit</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/umask.html#top'>umask</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/who.html#top'>who</a></li>
 </ul>
 
 <ul>
 <h2>Terminal</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/stty.html#top'>stty</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tabs.html#top'>tabs</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tty.html#top'>tty</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/stty.html#top'>stty</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/tabs.html#top'>tabs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/tty.html#top'>tty</a></li>
 </ul>
 
 <ul>
 <h2>Comm</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mailx.html#top'>mailx</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mesg.html#top'>mesg</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/talk.html#top'>talk</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uucp.html#top'>uucp</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uudecode.html#top'>uudecode</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uuencode.html#top'>uuencode</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uustat.html#top'>uustat</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uux.html#top'>uux</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/mailx.html#top'>mailx</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/mesg.html#top'>mesg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/talk.html#top'>talk</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uucp.html#top'>uucp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uudecode.html#top'>uudecode</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uuencode.html#top'>uuencode</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uustat.html#top'>uustat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uux.html#top'>uux</a></li>
 </ul>
 
 <ul>
 <h2>Compression</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/compress.html#top'>compress</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html#top'>pax</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uncompress.html#top'>uncompress</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/zcat.html#top'>zcat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/compress.html#top'>compress</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/pax.html#top'>pax</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/uncompress.html#top'>uncompress</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/zcat.html#top'>zcat</a></li>
 </ul>
 
 <div class='misc'>
 
 <ul>
 <h2>Message Queues</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ipcrm.html#top'>ipcrm</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ipcs.html#top'>ipcs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ipcrm.html#top'>ipcrm</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/ipcs.html#top'>ipcs</a></li>
 </ul>
 
 <ul>
 <h2>Print</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/lp.html#top'>lp</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pr.html#top'>pr</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/lp.html#top'>lp</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/pr.html#top'>pr</a></li>
 </ul>
 
 <ul>
 <h2>Batch Jobs</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qalter.html#top'>qalter</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qdel.html#top'>qdel</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qhold.html#top'>qhold</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qmove.html#top'>qmove</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qmsg.html#top'>qmsg</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qrerun.html#top'>qrerun</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qrls.html#top'>qrls</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qselect.html#top'>qselect</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qsig.html#top'>qsig</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qstat.html#top'>qstat</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/qsub.html#top'>qsub</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qalter.html#top'>qalter</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qdel.html#top'>qdel</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qhold.html#top'>qhold</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qmove.html#top'>qmove</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qmsg.html#top'>qmsg</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qrerun.html#top'>qrerun</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qrls.html#top'>qrls</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qselect.html#top'>qselect</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qsig.html#top'>qsig</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qstat.html#top'>qstat</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/qsub.html#top'>qsub</a></li>
 </ul>
 
 <ul>
 <h2>SCCS</h2>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/admin.html#top'>admin</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/delta.html#top'>delta</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/get.html#top'>get</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/prs.html#top'>prs</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/rmdel.html#top'>rmdel</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sact.html#top'>sact</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sccs.html#top'>sccs</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/unget.html#top'>unget</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/val.html#top'>val</a></li>
-<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799/utilities/what.html#top'>what</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/admin.html#top'>admin</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/delta.html#top'>delta</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/get.html#top'>get</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/prs.html#top'>prs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/rmdel.html#top'>rmdel</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sact.html#top'>sact</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sccs.html#top'>sccs</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/unget.html#top'>unget</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/val.html#top'>val</a></li>
+<li><a href='https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/what.html#top'>what</a></li>
 </ul>
 
 </div>

--- a/talk.html
+++ b/talk.html
@@ -12,23 +12,21 @@
 
   <p>
     An introductory talk on UNIX shell programming by
-    <a href='http://2ndscale.com/'>Ryan Tomayko</a>
+    <a href='https://tomayko.com'>Ryan Tomayko</a>
     presented at
-    <a href='http://gogaruco.com/'>GoGaRuCo 2010</a>, a regional Ruby conference
+    <a href='https://github.com/gogaruco'>GoGaRuCo 2010</a>, a regional Ruby conference
     in San Francisco.
   </p>
 
   <div id='video-embed'>
-    <video id="html5-player" controls="" poster="http://confreaks.net/system/videos/images/363/preview/363-gogaruco2010-the-shell-hater-s-handbook-thumb_0000.png?1302676698">
-      <source src="http://confreaks.net/system/assets/datas/1177/original/363-gogaruco2010-the-shell-hater-s-handbook-small.mp4">
-    </video>
+    <iframe width="1280" height="720" src="https://www.youtube.com/embed/olH-9b3VJfs" title="GoGaRuCo 2010 - The Shell Hater&#39;s Handbook by: Ryan Tomayko" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     <p class='confreaks'>
-      Video graciously provided by <a href="http://confreaks.net/videos/363">Confreaks, LLC.</a>
+      Video graciously provided by <a href="https://confreaks.com">Confreaks, LLC.</a>
     </p>
   </div>
 
   <p class='video-links'>
-    <a href="http://confreaks.net/videos/363">More Video</a> |
+    <a href="https://www.youtube.com/playlist?list=PLE7tQUdRKcybZLrVKlDUMgcMEchVqrpl5">More Video</a> |
     <a href="deck">Slide Deck</a>
   </p>
 
@@ -43,7 +41,7 @@
   <p>
 
   <p>
-    <strong><a href="http://2ndscale.com/rtomayko/2011/awkward-ruby">AWK-ward Ruby</a></strong><br>
+    <strong><a href="https://tomayko.com/blog/2011/awkward-ruby">AWK-ward Ruby</a></strong><br>
     A look at the evolution of features through AWK, Perl, and Ruby. This was to be
     published as a companion piece to the talk in GoGaRuCo's post-conference
     wrap-up magazine.


### PR DESCRIPTION
This might be a yell into the void, but here goes.

Update URLs in three ways:

* Use `https://` scheme and `pubs.opengroup.org` domain for all the documentation URLs. This eliminates a redirect from the `www.opengroup.org` domain, but also fixes failures to load that I am seeing in Firefox and Safari. (Possibly these are my fault, although if so, I'm not sure how. I filed a [webcompat bug](https://github.com/webcompat/web-bugs/issues/149354#issuecomment-2690131777) for the Firefox failures, but so far they can't replicate.)
* Update links to point to the 2018 version of the standard.
* Fix dead links on the talk page to point to their best replacements as I could find them in 2025

Don't touch any of the URLs in the slides